### PR TITLE
Exit with non zero

### DIFF
--- a/doc/Options.md
+++ b/doc/Options.md
@@ -1,9 +1,9 @@
 Options.js
 ==========
 
-Options.js contains the options object of default settings for Nodelint and JSLint.  
-  
-  
+Options.js contains the options object of default settings for Nodelint and JSLint.
+
+
 
  - **-l FILE, --logfile=FILE:** Define a logfile to output results to.
 
@@ -14,6 +14,8 @@ Options.js contains the options object of default settings for Nodelint and JSLi
  - **-c, --no-color:** Disable coloring of output.
 
  - **-v, --verbose:** Verbose mode. Outputs processing information like what directory is currently being read, or what file is currently being linted.
+
+ - **-e, exit-with-non-zero:** Exit with non-zero status code if at least one of the jslint test fails. This is useful when running Nodelint through command line and integrating it with different build tools.
 
  - **-p, --show-passed:** Output list of files that passed jslint.
 

--- a/lib/nodelint/Help.js
+++ b/lib/nodelint/Help.js
@@ -57,6 +57,11 @@ module.exports = [
 	"\tOutput missing files that were expected.",
 	"",
 
+	// Exit with non-zero status code
+	Color.red( "  -e, --exit-with-non-zero" ),
+	"\tExit with non-zero status code if at least one of the tests fails.",
+	"",
+
 	// Show warnings
 	Color.red( "  -w, --show-warnings" ),
 	"\tOutput warning messages during processing.",

--- a/lib/nodelint/Nodelint.js
+++ b/lib/nodelint/Nodelint.js
@@ -7,7 +7,8 @@
 var _Nodelint = global.Nodelint,
 	fs = require('fs'),
 	sys = require('sys'),
-	Nodelint, Render, Tracking, Color, options;
+	Nodelint, Render, Tracking, Color, options,
+	error_count = 0;
 
 
 global.Nodelint = Nodelint = function( Files, Options, Callback ) {
@@ -38,7 +39,7 @@ global.Nodelint = Nodelint = function( Files, Options, Callback ) {
 		// Write to log files for attachment purposes
 		if ( Options.logfile ) {
 			fs.writeFile( Options.logfile, format.logfile, 'utf8', function( e ) {
-				var info = e ? 
+				var info = e ?
 					"Unable to write to logfile - " + ( e.message || e ) :
 					"Logs have been recorded to " + Options.logfile;
 
@@ -118,6 +119,7 @@ else if ( argv.options[ 'Nodelint-cli' ] || Nodelint.Options[ 'Nodelint-cli' ] )
 		}
 		else {
 			sys.puts( results.output );
+			error_count = results.count.errors;
 		}
 	});
 }
@@ -134,3 +136,10 @@ else if ( argv.options[ 'Nodelint-pre-commit-all'] || Nodelint.Options[ 'Nodelin
 // Reassign the global Nodelint back to it's original owner, and export Nodelint
 global.Nodelint = _Nodelint;
 module.exports = Nodelint;
+
+process.on('exit', function() {
+  if (error_count > 0 && argv.options[ 'exit-with-non-zero' ] &&
+      argv.options[ 'exit-with-non-zero' ] === true) {
+	  process.reallyExit( 1 );
+	}
+});

--- a/lib/nodelint/Options.js
+++ b/lib/nodelint/Options.js
@@ -24,6 +24,9 @@ module.exports = {
 	// Display processing info to the terminal
 	'verbose': false,
 
+	// Exit with non-zero status code if at least one of the tests fails
+	'exit-with-non-zero': false,
+
 	// Show files that passes JSLINT in output
 	'show-passed': false,
 
@@ -74,6 +77,7 @@ module.exports = {
 		'l': {
 			'long': 'logfile',
 			'expect': true,
+
 			'default': null
 		},
 
@@ -101,6 +105,13 @@ module.exports = {
 		// Shortcut for verbose mode
 		'v': {
 			'long': 'verbose',
+			'expect': false,
+			'default': true
+		},
+
+		// Shortcut for exit-non-zero
+		'e': {
+			'long': 'exit-with-non-zero',
 			'expect': false,
 			'default': true
 		},


### PR DESCRIPTION
Currently, if you don't run Nodelint as a pre-commit hook there is no option to make it exit with a non-zero status code.

This commit adds "exit-with-non-zero" option which makes the process exit with non-zero status code when running it through the command line (Nodelint-cli == true) if at least one of the jslint test fails.

This comes handy when integrating Nodelint with different build tools.
